### PR TITLE
Updated Version check and minor cleanup

### DIFF
--- a/wave.lua
+++ b/wave.lua
@@ -1,8 +1,8 @@
 --[[
-wave version 0.1.6
+wave version 0.1.7
 
 The MIT License (MIT)
-Copyright (c) 2021 CrazedProgrammer
+Copyright (c) 2022 CrazedProgrammer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -30,8 +30,13 @@ wave._defaultThrottle = 99
 wave._defaultClipMode = 1
 wave._maxInterval = 1
 wave._isNewSystem = false
-if _HOST then
-	wave._isNewSystem = _HOST:sub(15, #_HOST) >= "1.80"
+if _HOST then -- Checks the version of computer craft the program is currently running in and determines whether to use the new system or not (_isNewSystem)
+	local _, _, numMajorVersion, numMinorVersion = string.find(_HOST, "(%d+).(%d+)")
+	if tonumber(numMajorVersion) > 1 then
+		wave._isNewSystem = true
+	elseif tonumber(numMajorVersion) == 1 and tonumber(numMinorVersion) >= 80 then
+		wave._isNewSystem = true
+	end
 end
 
 wave.context = { }
@@ -381,7 +386,7 @@ function wave.loadTrack(path)
 			track.layers[i].volume = volume / 100
 		else
 			track.layers[i].name = name
-			track.layers[i].volume = readInt(1) / 100			
+			track.layers[i].volume = readInt(1) / 100
 		end
 	end
 


### PR DESCRIPTION
# Summary

## Version Check

Recently used the API within a modified version of [wave-amp](https://github.com/CrazedProgrammer/wave-amp/) and noticed the program wasn't working within newer versions of CC: Tweaked (version 1.100.1 in my case). Due to an under sight within the API, I realized that it was running into issues because it was unable to properly process triple-digit version numbers. I have made a fix within the program that should be able to handle any number of digits

## Cleanup

Saw a single line with leading white space and got rid of it

## Other Thoughts

I saw the edit within the copyright from a previous commit and I was thinking, maybe a contribution file could be made? I have updated the copyright year to stay uniform, however, I feel it would be more accurate to copyright each contributors' work. Don't know many details regarding copyright, although I feel this should be brought up eventually with more people contributing